### PR TITLE
fix: declare runtime dependencies for production installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/node": "^14.11.8",
     "concurrently": "^5.3.0",
     "coveralls": "^3.1.0",
-    "dotenv": "^8.2.0",
     "jest": "^26.5.3",
     "onchange": "^7.0.2",
     "prettier": "^2.1.2",
@@ -54,7 +53,9 @@
   "dependencies": {
     "@google-cloud/translate": "^4.1.3",
     "dot-object": "^2.1.4",
+    "dotenv": "^8.2.0",
     "fraud": "^5.2.0",
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "mkdirp": "^0.5.6"
   }
 }

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -1,0 +1,7 @@
+const packageJson = require("../package.json");
+
+test("declares modules needed by production installs", () => {
+  expect(packageJson.dependencies).toHaveProperty("dotenv");
+  expect(packageJson.dependencies).toHaveProperty("mkdirp");
+  expect(packageJson.devDependencies || {}).not.toHaveProperty("dotenv");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,6 +3262,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -3274,6 +3279,13 @@ mkdirp@1.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mkdirp@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
- Moves `dotenv` into runtime dependencies so published installs can load `dist/index.js`.
- Adds `mkdirp@0.5.x` as a runtime dependency to satisfy `fraud`'s callback-style `mkdirp` require.
- Adds a manifest regression test for production-install dependencies.

Fixes #299

## Test plan
- `yarn build`
- `yarn jest tests/package.test.ts --runInBand`
- `npm pack` + install the tarball into a temp project with `--omit=dev`, then `require("auto-i18n")`
- Full `yarn test-without-coverage --runInBand` still fails before and after this change because the existing integration tests call Google Translate without valid API credentials/scopes in this environment.
