### PR TITLE
ci: add hermetic Node test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test on Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - name: Enable Yarn 1
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build TypeScript
+        run: yarn build
+      - name: Run tests
+        run: yarn test-without-coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌐 Auto I18N
 
-[![Travis CI](https://img.shields.io/travis/AnandChowdhary/auto-i18n.svg)](https://travis-ci.org/AnandChowdhary/auto-i18n)
+[![Node CI](https://github.com/AnandChowdhary/auto-i18n/actions/workflows/ci.yml/badge.svg)](https://github.com/AnandChowdhary/auto-i18n/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/AnandChowdhary/auto-i18n/badge.svg?branch=master&v=2)](https://coveralls.io/github/AnandChowdhary/auto-i18n?branch=master)
 [![GitHub](https://img.shields.io/github/license/anandchowdhary/auto-i18n.svg)](https://github.com/AnandChowdhary/auto-i18n/blob/master/LICENSE)
 ![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/AnandChowdhary/auto-i18n.svg)

--- a/index.ts
+++ b/index.ts
@@ -129,7 +129,7 @@ const generate = async (
       undefined,
       directory
     );
-    writeJson(join(fileUrl, "..", `${singleLang}.json`), translated);
+    await writeJson(join(fileUrl, "..", `${singleLang}.json`), translated);
   }
 };
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,39 +1,66 @@
+jest.mock("@google-cloud/translate", () => {
+  const translations: { [language: string]: { [term: string]: string } } = {
+    de: { hello: "hallo", world: "welt" },
+    fr: { hello: "bonjour", world: "monde" },
+    nl: { hello: "hallo", world: "wereld" },
+  };
+
+  return {
+    Translate: jest.fn().mockImplementation(() => ({
+      translate: jest.fn(async (term: string, language: string) => {
+        if (!term) return [];
+        return [
+          translations[language]?.[term.toLowerCase()] || `${term}-${language}`,
+        ];
+      }),
+    })),
+  };
+});
+
 import {
   translate,
   translateObject,
   translateFile,
   generate,
-  translateFileSingle
+  translateFileSingle,
 } from "../index";
-import { readJson, writeJson, mkdirp } from "fs-extra";
+import { readJson, writeJson, mkdirp, remove } from "fs-extra";
 import { join } from "path";
 
+const testRoot = join(__dirname, "..", ".cache", "tests");
+const translationCache = join(testRoot, "translations");
+
+beforeAll(async () => {
+  await remove(testRoot);
+  await mkdirp(testRoot);
+});
+
 test("translate a word", async () => {
-  const translated = <string>await translate("hello", "fr");
+  const translated = <string>(
+    await translate("hello", "fr", translationCache, true)
+  );
   expect(translated.toLowerCase().trim()).toBe("bonjour");
 });
 
-test("invalid language would fail", () => {
-  translate("hello", "xx")
-    .then(() => {
-      throw new Error("did not fail");
-    })
-    .catch(error => expect(error.message).toBe("invalid language: xx"));
+test("invalid language would fail", async () => {
+  await expect(translate("hello", "xx", translationCache)).rejects.toThrow(
+    "invalid language: xx"
+  );
 });
 
-test("invalid api request", () => {
-  translate("", "fr", undefined, true)
-    .then(() => {
-      throw new Error("did not fail");
-    })
-    .catch(error => expect(error.message).toBe("unable to translate from api"));
+test("invalid api request", async () => {
+  await expect(translate("", "fr", translationCache, true)).rejects.toThrow(
+    "unable to translate from api"
+  );
 });
 
 test("translating an object", async () => {
   interface i {
     [index: string]: string;
   }
-  const translated = <i>await translateObject({ hello: "hello" }, "fr");
+  const translated = <i>(
+    await translateObject({ hello: "hello" }, "fr", translationCache)
+  );
   expect(translated.hello.toLowerCase().trim()).toBe("bonjour");
 });
 
@@ -44,86 +71,91 @@ test("translating a more complicated object", async () => {
   const translated = <i>await translateObject(
     {
       hello: {
-        world: ["hello"]
-      }
+        world: ["hello"],
+      },
     },
-    "fr"
+    "fr",
+    translationCache
   );
   expect(translated.hello.world[0].toLowerCase().trim()).toBe("bonjour");
 });
 
 test("translation comes from cache", async () => {
-  const translated = <string>await translate("hello", "fr");
+  await translate("hello", "fr", translationCache, true);
   const translatedFromCache = <any>(
-    await translate("hello", "fr", undefined, undefined, true)
+    await translate("hello", "fr", translationCache, false, true)
   );
   expect(translatedFromCache.from).toBe("cache");
 });
 
-test("translation comes from cache", async () => {
-  const translated = <string>await translate("hello", "fr");
+test("translation can be forced to refresh from api", async () => {
+  await translate("hello", "fr", translationCache, true);
   const translatedFromApi = <any>(
-    await translate("hello", "fr", undefined, true, true)
+    await translate("hello", "fr", translationCache, true, true)
   );
   expect(translatedFromApi.from).toBe("api");
 });
 
 test("translate a regular file", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "test-1.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { hello: "hello" });
-  const translated = <any>await translateFile(filePath, "fr");
+  const translated = <any>(
+    await translateFile(filePath, "fr", false, "en", translationCache)
+  );
   expect(translated.hello.toLowerCase().trim()).toBe("bonjour");
 });
 
 test("translate a single file with many languages", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "test-2.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { en: { hello: "hello" } });
-  const translated = <any>await translateFile(filePath, "fr");
+  const translated = <any>(
+    await translateFile(filePath, "fr", false, "en", translationCache)
+  );
   expect(translated.fr.hello.toLowerCase().trim()).toBe("bonjour");
 });
 
 test("invalid single file would fail", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "test-3.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { hello: "hello" });
-  translateFileSingle(filePath, ["fr"])
-    .then(() => {
-      throw new Error("did not fail");
-    })
-    .catch(error => expect(error.message).toBe("not single translation file"));
+  await expect(
+    translateFileSingle(filePath, ["fr"], false, "en", translationCache)
+  ).rejects.toThrow("not single translation file");
 });
 
 test("write single file with many languages", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "test-4.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { en: { hello: "hello" } });
-  <any>await translateFileSingle(filePath, ["fr"], true);
-  const translated = await readJson(join(filePath, "..", "fr.json"));
-  expect(translated.hello.toLowerCase().trim()).toBe("bonjour");
+  <any>(
+    await translateFileSingle(filePath, ["fr"], true, "en", translationCache)
+  );
+  const translated = await readJson(filePath);
+  expect(translated.fr.hello.toLowerCase().trim()).toBe("bonjour");
 });
 
 test("save a translated file", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "test-5.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { hello: "hello" });
-  <any>await translateFile(filePath, "fr", true);
-  const translated = await readJson(join(filePath, "..", "fr.json"));
+  <any>await translateFile(filePath, "fr", true, "en", translationCache);
+  const translated = await readJson(filePath);
   expect(translated.hello.toLowerCase().trim()).toBe("bonjour");
 });
 
 test("generate translations", async () => {
-  const dirPath = join(__dirname, "test-cache");
+  const dirPath = join(testRoot, "files");
   const filePath = join(dirPath, "en.json");
   await mkdirp(dirPath);
   await writeJson(filePath, { hello: "hello" });
-  <any>await generate(filePath, ["nl", "de"]);
+  <any>await generate(filePath, ["nl", "de"], translationCache);
   const translated = await readJson(join(filePath, "..", "nl.json"));
-  expect(translated.hello.toLowerCase().trim()).toBeDefined();
+  expect(translated.hello.toLowerCase().trim()).toBe("hallo");
 });


### PR DESCRIPTION
## Summary
- Add a GitHub Actions Node CI workflow for Yarn 1 builds/tests on Node 20 and 22
- Mock Google Cloud Translate in the Jest suite so tests no longer require live API credentials
- Await generated language-file writes so `generate()` resolves after files are persisted
- Replace the stale Travis badge with the new Node CI badge

## Test plan
- `yarn install --frozen-lockfile`
- `yarn build`
- `yarn test-without-coverage`
- `yarn prettier --check tests/index.test.ts .github/workflows/ci.yml`
- Parsed `.github/workflows/ci.yml` with PyYAML
- Validated `.github/workflows/ci.yml` with actionlint via stdin
- Added-line security scan clean
- Independent Claude review passed
